### PR TITLE
Add before(Each) and after(Each) hooks

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -8,12 +8,21 @@ module.exports = function migrate(migrations, driver, options, cb) {
     if (arguments.length === 3) return module.exports(arguments[0], arguments[1], {}, arguments[2])
     var connected = false
 
-    async.seq(connect, ensure, lock, getMigrations, calculateDeltas, runMigrations)(function(err) {
+    var before = options.before || function(migrations, cb) { return cb(null, migrations) }
+    var after = options.after || function(migrations, cb) { return cb(null, migrations) }
+
+    var beforeEach = options.beforeEach || function(migration, cb) { return cb(null, migration) }
+    var afterEach = options.afterEach || function(migration, cb) { return cb(null, migration) }
+
+    async.seq(connect, ensure, lock, getMigrations, calculateDeltas, before,
+              runMigrations, after)(handleConnectionError)
+
+    function handleConnectionError(err) {
         if (!connected) return cb(err)
         async.seq(unlock, disconnect)(function() {
             cb(err)
         })
-    })
+    }
 
     function connect(cb) {
         debug('Connecting driver')
@@ -55,14 +64,23 @@ module.exports = function migrate(migrations, driver, options, cb) {
     }
 
     function runMigrations(migrations, cb) {
+        if (migrations.length === 0) {
+            return cb(null, migrations)
+        }
+
         debug('Running %d migrations', migrations.length)
         async.eachSeries(migrations, function(migration, cb) {
-            if (migration.hasOwnProperty('audit') && !migration.hasOwnProperty('directives')) {
-                if (!options.quiet) console.warn("The 'audit' option is deprecated. Please use 'directives.audit' instead. You can disable this warning by setting 'quiet' to true.");
-                _.set(migration, 'directives.audit', migration.audit)
-            }
-            driver.runMigration(migration, cb)
-        }, guard(cb))
+            async.seq(beforeEach, function(migration, cb) {
+                if (migration.hasOwnProperty('audit') && !migration.hasOwnProperty('directives')) {
+                    if (!options.quiet) console.warn("The 'audit' option is deprecated. Please use 'directives.audit' instead. You can disable this warning by setting 'quiet' to true.");
+                    _.set(migration, 'directives.audit', migration.audit)
+                }
+                driver.runMigration(migration, function(err) {
+                    if (err) return cb(err);
+                    return cb(null, migration)
+                })
+            }, afterEach)(migration, cb)
+        }, function(err) { return cb(err, migrations) })
     }
 
     function unlock(cb) {


### PR DESCRIPTION
I added before(Each) and after(Each) hooks to marv. Is there any interest of merging this into the mainline? Possible use case would be creating/updating views after a schema change.