### PR TITLE
Prevents Marv from crashing on directories with sub-folders

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -14,13 +14,26 @@ module.exports = function scanDirectory(directory, options, cb) {
     delete options.migrations;
   }
 
-  var scanDirectory = async.seq(readDirectory, getMarvRc, getMigrations);
+  var scanDirectory = async.seq(readDirectory, ensureFilesNotFolders, getMarvRc, getMigrations);
   var getMigration = async.seq(readFile, buildMigration);
   var config = _.merge({ filter: /.*/, directives: {} }, options);
 
   function readDirectory(cb) {
     debug('Reading directory %s', directory);
     fs.readdir(directory, cb);
+  }
+  function ensureFilesNotFolders(files, cb) {
+    debug('Ensuring that no files read in the directory were folders', directory);
+    let filePaths = files.map(function(file){
+      return path.join(directory, file);
+    });
+    async.map(filePaths, fs.lstat, function(err, results){
+      if (err) return cb(err);
+      var directoryItemsWithoutFolders = files.filter(function(file, index){
+        return !results[index].isDirectory();
+      });
+      cb(null, directoryItemsWithoutFolders);
+    });
   }
 
   function getMarvRc(files, cb) {


### PR DESCRIPTION
Adds an async sequence step in scan.js that filters any folders from the directory items read in fs.readdir(). The current behavior is an error state as fs.readFile attempts to read a directory and halts the execution of the code.

This is important to allow for flexibility in structuring sensibly organized migrations, especially ones worked on for two different organization projects simultaneously. There's a current issue when two different teams develop migrations that run through marv on a dev database such as 00001.sql and 00002.sql, but the 00002.sql is finished with development first. Due to marv's checks against the level within the namespace, if 00002.sql is integrated first, the 00001.sql file must be renamed, then manually marked as completed in the dev database to avoid any conflicts. This lets developers work on multiple projects harmoniously while maintaining an ordered structure, but able to be merge and then run them on existing codebases and deployments in any order.

For example, this would allow marv to be called intelligently, once per directory, on a structure such as:

```bash
migrations/
├── .marvrc
├── 00001_generate_schema.sql
└── 00002_other_base_level_operation.sql
├── namespace_00001_project-1/
│   ├── .marvrc
│   └── 00001_first_namespaced_project_1_code.sql
├── namespace_00002_project-2/
│   ├── .marvrc
│   ├── 00001_project_2_namespaced_code.sql
│   └── 00001_more_namespaced_code.sql
```
If namespace_00002_project-2 finishes development first, it can be merged in without having to rename, re-cache, and alter the dev database of the namespace_00001_project-1 project.

This would greatly improve configurability for those willing to write code to direct marv through these structures in an ordered fashion.