### PR TITLE
typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Directives allow you to customise the behaviour of migrations. You can specify d
 1. Programatically via marv.scan
 
    ```js
-   const migrations = await marv.scan(directory, { filter: /\.sql$/ }, { directives: { audit: false } });
+   const migrations = await marv.scan(directory, { filter: /\.sql$/, directives: { audit: false } });
    ```
 
 1. Via .marvrc


### PR DESCRIPTION
should be a single config object from looking at the docs / code.